### PR TITLE
Add name mapping via a JSON file

### DIFF
--- a/NameMapping.md
+++ b/NameMapping.md
@@ -1,0 +1,100 @@
+# Name Map
+
+**OData2Poco** can do explicit mapping of the names coming from
+the OData feed. This is done using a JSON file and specifying
+`--name-map path/to/name-map.json` on the command line.
+
+For both types of mapping, if an explicit map is not
+found, then the program reverts to the setting of `--case`.
+Conversely, if a mapping is found, then the --case is ignored
+for that class or property.
+
+## Class Name Map
+
+The class name map is a simple 1:1 match based on the original
+name. The match is not case sensitive, and typical map would
+look like:
+
+```json
+{
+    "ClassNameMap": [
+        {
+            "OldName": "account",
+            "NewName": "MoreSpecificAccount"
+        }
+    ]
+}
+```
+
+## Property Name Map
+
+The property name map has an extra layer of naming
+the original class name or a special value of "ALL".
+The "ALL" map also supports regex matching and the
+regex matching is triggered by a leading `^` in the
+OldName.
+
+```json
+{
+    "PropertyNameMap": {
+        "account": [
+            {
+                "OldName": "last_name",
+                "NewName": "Surname",
+            }
+        ],
+        "ALL": [
+            {
+                "OldName": "cr9f6_costapprover",
+                "NewName": "CostApprover"
+            },
+            {
+                "OldName": "^.*approver$",
+                "NewName": "Approver"
+            }
+        ]
+    }
+}
+```
+
+When mapping a property, first a match is attempted
+on the properties with a specific class name (account
+in this example). Then a check is made in the ALL
+entries but with a case-insensitive exact match to
+the OldName. Lastly, an attempt is made to match the
+ALL entries using a regex if the OldName starts
+with a `^`.
+
+### Complete File
+
+The complete file would look like:
+
+```json
+{
+    "ClassNameMap": [
+        {
+            "OldName": "account",
+            "NewName": "MoreSpecificAccount"
+        }
+    ],
+    "PropertyNameMap": {
+        "account": [
+            {
+                "OldName": "last_name",
+                "NewName": "Surname",
+            }
+        ],
+        "ALL": [
+            {
+                "OldName": "cx6f4_costapprover",
+                "NewName": "CostApprover"
+            },
+            {
+                "OldName": "^.*approver$",
+                "NewName": "Approver"
+            }
+        ]
+    }
+}
+
+```

--- a/OData2Poco.Core/OptionManager.cs
+++ b/OData2Poco.Core/OptionManager.cs
@@ -26,6 +26,7 @@ namespace OData2Poco.CommandLine
                 NamespacePrefix = string.IsNullOrEmpty(PocoOptions.Namespace)
                     ? string.Empty : PocoOptions.Namespace,
                 NameCase = PocoOptions.NameCase.ToEnum<CaseEnum>(),
+                RenameMap = PocoOptions.RenameMap,
                 Attributes = PocoOptions.Attributes?.ToList(),
                 //obsolete
                 AddKeyAttribute = PocoOptions.Key,

--- a/OData2PocoLib/PocoClassGeneratorCs.cs
+++ b/OData2PocoLib/PocoClassGeneratorCs.cs
@@ -84,8 +84,8 @@ namespace OData2Poco
                 generator.ClassList = ModelFilter.FilterList(generatorClassList, setting.Include).ToList();
 
             //change case
-            if (setting.EntityNameCase != CaseEnum.None)
-                ModelChangeCase.RenameClasses(generatorClassList, setting.EntityNameCase);
+            if (setting.EntityNameCase != CaseEnum.None || setting.RenameMap is not null)
+                ModelChangeCase.RenameClasses(generatorClassList, setting.EntityNameCase, setting.RenameMap);
 
             //check reserved keywords
             ModelManager.RenameReservedWords(generatorClassList);

--- a/OData2PocoLib/PocoSetting.cs
+++ b/OData2PocoLib/PocoSetting.cs
@@ -56,6 +56,11 @@ namespace OData2Poco
         /// </summary>
         public CaseEnum EntityNameCase { get; set; }
 
+        /// <summary>
+        /// Explicit rename map.
+        /// </summary>
+        public RenameMap? RenameMap { get; set; }
+
         //add attributes: key,req,dm,tab,json,proto,display and db
         public List<string> Attributes { get; set; }
 

--- a/OData2PocoLib/RenameMap.cs
+++ b/OData2PocoLib/RenameMap.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+
+namespace OData2Poco
+{
+    public class RenameMap
+    {
+        // This is a list so we have the option to control how we match
+        // the OldName.
+        public List<ClassNameMap> ClassNameMap { get; set;  } = new List<ClassNameMap>();
+
+        public Dictionary<string, List<PropertyNameMap>> PropertyNameMap { get; set; } = new Dictionary<string, List<PropertyNameMap>>();
+    }
+
+    public class ClassNameMap
+    {
+        public string OldName { get; set; } = string.Empty;
+
+        public string NewName { get; set; } = string.Empty;
+    }
+
+    public class PropertyNameMap
+    {
+        public string OldName { get; set; } = string.Empty;
+
+        public string NewName { get; set; } = string.Empty;
+    }
+
+}
+


### PR DESCRIPTION
Here is my first attempt at https://github.com/moh-hassan/odata2poco/issues/39 which allows explicit mapping of class and property names, configured via a JSON file. Note the NameMapping.md file at the top level directory which explains the format of the file.

Feedback welcome!

--Bill
